### PR TITLE
added default RDS storage type to General SSD

### DIFF
--- a/include/rds/rds.rb
+++ b/include/rds/rds.rb
@@ -23,6 +23,7 @@ RDS do
       Ref "DBSubnetGroup"
     end
     Engine "MariaDB"
+    StorageType "gp2"
     MasterUsername "amimoto"
     MasterUserPassword do
       Ref "MySQLPassword"


### PR DESCRIPTION
When left blank, the default storage type for RDS is Magnetic. This will set the default to General SSD for better performance. Changing this is still possible during launch for those who want to use Magnetic.